### PR TITLE
Add tags directly in the span constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ use warnings;
 
 use Redis::OpenTracing;
 
-my $redis = Redis->new( );
+my $redis = Redis::OpenTracing->new( );
 
 my $value = $redis->get 'my-key';
 
@@ -21,7 +21,7 @@ my $value = $redis->get 'my-key';
 
 ## Description
 
-The example above will use the default Redis server (from `$ENV{REDIS}`) and the Global Tracer (from `$ENV{OPENTRACING_IMPLEMENTATION}`.
+The example above will use the default Redis server (from `$ENV{REDIS_SERVER}`) and the Global Tracer (from `$ENV{OPENTRACING_IMPLEMENTATION}`.
 It will create span with the name `Redis::GET`, enriched with package / subroutine name and line number for easy debugging.
 
 ## Author

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,5 @@
 requires                "Moo";
 requires                "OpenTracing::AutoScope";
-requires                "OpenTracing::GlobalTracer";
 requires                "Redis";
 requires                "Scalar::Util";
 requires                "Syntax::Feature::Maybe";

--- a/lib/Redis/OpenTracing.pm
+++ b/lib/Redis/OpenTracing.pm
@@ -77,23 +77,26 @@ sub AUTOLOAD {
     my $self = shift;
     
     my $method_call = do { $_ = $AUTOLOAD; s/.*:://; $_ };
+    my $db_statement = uc($method_call);
+    my $peer_address = $self->_peer_address( );
     
-    OpenTracing::AutoScope->start_guarded_span(
-        $self->_operation_name( $method_call ),
-        tags => {
-            'component'     => __PACKAGE__,
-            'db.statement'  => uc($method_call),
-            'db.type'       => 'redis',
-            maybe
-            'peer.address'  => $self->_peer_address( ),
-            'span.kind'     => 'client',
-        },
-    );
+    # minimize scope and duration of the wrapped method
+    do {
+        OpenTracing::AutoScope->start_guarded_span(
+            $self->_operation_name( $method_call ),
+            tags => {
+                'component'     => __PACKAGE__,
+                'db.statement'  => $db_statement,
+                'db.type'       => 'redis',
+                maybe
+                'peer.address'  => $peer_address,
+                'span.kind'     => 'client',
+            },
+        );
+        
+        return $self->redis->$method_call(@_);
+    }
     
-    return $self->redis->$method_call(@_);
-    
-    # this is a laymans way of doing it, there are no tags set, nor any other
-    # useful information passed on... patches welcome!
 }
 
 

--- a/lib/Redis/OpenTracing.pm
+++ b/lib/Redis/OpenTracing.pm
@@ -25,8 +25,8 @@ has 'redis' => (
 # _build_redis()
 #
 # returns a (auto-connected) Redis instance. We may opt for Redis::Fast instead,
-# but will leave that for a later itteration. It is always possible to
-# instantiate any client and inject it inti the constructor.
+# but will leave that for a later iteration. It is always possible to
+# instantiate any client and inject it into the constructor.
 #
 sub _build_redis {
     Redis->new
@@ -63,7 +63,7 @@ sub _build__peer_address {
     
     return "@{[ $self->redis->{ server } ]}"
         if exists $self->redis->{ server };
-    # currentl, we're fine with any stringification of a blessed hashref too
+    # currently, we're fine with any stringification of a blessed hashref too
     # but for Redis, Redis::Fast, Test::Mock::Redis, this is just a string
     
     return

--- a/lib/Redis/OpenTracing.pm
+++ b/lib/Redis/OpenTracing.pm
@@ -12,7 +12,6 @@ use Types::Standard qw/Maybe Object Str is_Str/;
 
 use Redis;
 use OpenTracing::AutoScope;
-use OpenTracing::GlobalTracer;
 use Scalar::Util 'blessed';
 
 

--- a/lib/Redis/OpenTracing.pod
+++ b/lib/Redis/OpenTracing.pod
@@ -24,8 +24,9 @@ Redis::OpenTracing - Wrap Redis inside OpenTracing
 
 =head1 DESCRIPTION
 
-The example above will use the default Redis server (from C<$ENV{REDIS}>) and
-the Global Tracer (from C<$ENV{OPENTRACING_IMPLEMENTATION}>.
+The example above will use the default Redis server
+(from C<$ENV{REDIS_SERVER}>) and the Global Tracer
+(from C<$ENV{OPENTRACING_IMPLEMENTATION}>.
 
 It will create span with the name C<Redis::GET>, enriched with package /
 subroutine name and line number for easy debugging.
@@ -52,7 +53,7 @@ Creates a new C<Redis::OpenTracing> client.
 
 =item C<redis>
 
-A (exisitng) Redis client. This must be something like an instance of L<Redis>,
+A (existing) Redis client. This must be something like an instance of L<Redis>,
 and implement its methods to work properly.
 
 =back


### PR DESCRIPTION
AutoScope allows to pass tags as a constructor argument, so there is no need to get the same span from the tracer just to do that. The `do` block is redundant. I've also fixed some typos in the comments and documentation.